### PR TITLE
Remove BearerAuthOverridingHeadersTransport

### DIFF
--- a/auth_transports.go
+++ b/auth_transports.go
@@ -1,9 +1,6 @@
 package httputils
 
-import (
-	"net/http"
-	"strings"
-)
+import "net/http"
 
 type BearerAuthTransport struct {
 	Token     string
@@ -23,39 +20,4 @@ type BasicAuthTransport struct {
 func (t *BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.SetBasicAuth(t.Username, t.Password)
 	return t.Transport.RoundTrip(req)
-}
-
-// BearerAuthOverridingHeadersTransport wraps a RoundTripper. It replaces the existing Authorization header's prefix,
-// allowing f.ex. "Authorization: BearerToken foo" to be changed to "Authorization: Bearer foo".
-// Based on https://sgeb.io/posts/fix-go-oauth2-case-sensitive-bearer-auth-headers/
-type BearerAuthOverridingHeadersTransport struct {
-	rt     http.RoundTripper
-	prefix string
-}
-
-// RoundTrip satisfies the RoundTripper interface. It replaces authorization
-// headers of scheme `bearer` by capitalized `Bearer` (as per OAuth 2.0 spec).
-func (t *BearerAuthOverridingHeadersTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	auth := req.Header.Get("Authorization")
-	parts := strings.Split(auth, " ")
-	if len(parts) > 1 {
-		auth = t.prefix + auth[len(parts[0]):]
-	}
-	req2 := cloneRequest(req) // per RoundTripper contract
-	req2.Header.Set("Authorization", auth)
-	return t.rt.RoundTrip(req2)
-}
-
-// cloneRequest returns a clone of the provided *http.Request.
-// The clone is a shallow copy of the struct and its Header map.
-func cloneRequest(r *http.Request) *http.Request {
-	// shallow copy of the struct
-	r2 := new(http.Request)
-	*r2 = *r
-	// deep copy of the Header
-	r2.Header = make(http.Header, len(r.Header))
-	for k, s := range r.Header {
-		r2.Header[k] = append([]string(nil), s...)
-	}
-	return r2
 }

--- a/client.go
+++ b/client.go
@@ -44,7 +44,6 @@ type HTTPClientConfig struct {
 	password           string
 	oauth2TokenSource  oauth2.TokenSource
 	logCall            CallLogger
-	authHeaderPrefix   string
 }
 
 type HTTPClientConfigOpt func(config *HTTPClientConfig)
@@ -121,12 +120,6 @@ func UseOAuth2(source oauth2.TokenSource) HTTPClientConfigOpt {
 	}
 }
 
-func OverrideAuthHeaderPrefix(prefix string) HTTPClientConfigOpt {
-	return func(config *HTTPClientConfig) {
-		config.authHeaderPrefix = prefix
-	}
-}
-
 func LogCalls(logger CallLogger) HTTPClientConfigOpt {
 	return func(config *HTTPClientConfig) {
 		config.logCall = logger
@@ -169,14 +162,6 @@ func NewHTTPClient(opts ...HTTPClientConfigOpt) *HTTPClient {
 
 func selectTransport(config HTTPClientConfig) http.RoundTripper {
 	transport := createTransport(config)
-
-	if config.authHeaderPrefix != "" {
-		var rt http.RoundTripper = &BearerAuthOverridingHeadersTransport{
-			rt:     transport,
-			prefix: config.authHeaderPrefix,
-		}
-		transport = rt
-	}
 
 	if config.username != "" || config.password != "" {
 		transport = &BasicAuthTransport{

--- a/client_test.go
+++ b/client_test.go
@@ -355,19 +355,6 @@ func Test_HttpClient_Get_UseBearerAuth(t *testing.T) {
 	assert.Equal(t, "Bearer some-token", verify.authorization)
 }
 
-func Test_HttpClient_Get_OverrideAuthHeaderPrefix(t *testing.T) {
-	server, verify := testMockServer(t, mockResponses(http.StatusOK, `{}`))
-
-	client := NewHTTPClient(UseBearerAuth("some-token"), OverrideAuthHeaderPrefix("BearerPrefix"))
-	request := testEntity{Field: "send"}
-
-	err := client.Get(server.URL+"/", &request)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 1, verify.calls)
-	assert.Equal(t, "BearerPrefix some-token", verify.authorization)
-}
-
 func Test_HttpClient_Get_UseBasicAuth(t *testing.T) {
 	server, verify := testMockServer(t, mockResponses(http.StatusOK, `{}`))
 


### PR DESCRIPTION
This reverts commit 4a6995f and 1e9669c.

As shown in https://github.com/snabble/orders/pull/642, this can be
more easily achieved with a custom token source.
