### PR TITLE
Add response body to http client errors

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -5,8 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/trace"
 	"io"
 	"net"
 	"net/http"
@@ -14,6 +12,9 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/snabble/go-logging/v2/tracex"
 	"github.com/snabble/go-logging/v2/tracex/datamap"


### PR DESCRIPTION
This makes it easier for client code to log the response body.

This can be quite useful when investigating responses from f.ex. third
parties that respond with unexpected errors that do not have a body that
fits into the expected responseBody structure.

See discussion in slack: https://snabble.slack.com/archives/C02AVUMNPJ8/p1730975615055719
