### PR TITLE
Generic wrapper that copies payload before unmarshalling

### DIFF
--- a/payloads.go
+++ b/payloads.go
@@ -1,0 +1,13 @@
+package httputils
+
+import "encoding/json"
+
+type JSONResponseWrapper[T any] struct {
+	Raw     []byte
+	Decoded T
+}
+
+func (w *JSONResponseWrapper[T]) UnmarshalJSON(data []byte) error {
+	copy(w.Raw, data)
+	return json.Unmarshal(data, &w.Decoded)
+}

--- a/payloads.go
+++ b/payloads.go
@@ -1,6 +1,8 @@
 package httputils
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 type JSONResponseWrapper[T any] struct {
 	Raw     []byte
@@ -8,6 +10,11 @@ type JSONResponseWrapper[T any] struct {
 }
 
 func (w *JSONResponseWrapper[T]) UnmarshalJSON(data []byte) error {
+	w.Raw = make([]byte, len(data))
 	copy(w.Raw, data)
 	return json.Unmarshal(data, &w.Decoded)
+}
+
+func (w *JSONResponseWrapper[T]) String() string {
+	return string(w.Raw)
 }


### PR DESCRIPTION
See discussion in https://github.com/snabble/importer-blocks/pull/173

Example usage in client code:

![image](https://github.com/user-attachments/assets/e580f346-28b5-4240-9c8a-283b08fe0320)
