### PR TITLE
Add type `StructuredError`

### DIFF
--- a/structured_error.go
+++ b/structured_error.go
@@ -1,0 +1,24 @@
+package httputils
+
+import (
+	"errors"
+	"fmt"
+)
+
+// StructuredError represents a structured error containing a type and a message.
+type StructuredError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// Error implements the Error interface for StructuredError.
+// It returns the error message formatted as "Type: Message".
+func (s StructuredError) Error() string {
+	return fmt.Sprintf("%s: %s", s.Type, s.Message)
+}
+
+// Is implements the Is method for the errors package.
+// It checks whether the target error is a StructuredError.
+func (s StructuredError) Is(target error) bool {
+	return errors.As(target, &StructuredError{})
+}

--- a/structured_error_test.go
+++ b/structured_error_test.go
@@ -1,0 +1,27 @@
+package httputils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_StructuredError_Error(t *testing.T) {
+	e := StructuredError{
+		Type:    "__type__",
+		Message: "__message__",
+	}
+	assert.Equal(t, "__type__: __message__", e.Error(), "should be equal")
+}
+
+func Test_StructuredError_Is(t *testing.T) {
+	e1 := StructuredError{Type: "__type_one__", Message: "__message_one__"}
+	e2 := StructuredError{Type: "__type_two__", Message: "__message_two__"}
+
+	assert.True(t, errors.Is(e1, e1), "e1 should be the same as e1")
+	assert.True(t, errors.Is(e1, e2), "e1 should be the same type as e2")
+
+	eNonStructured := errors.New("some other error")
+	assert.False(t, errors.Is(e1, eNonStructured), "e1 should not be the same type as a non-structured error")
+}


### PR DESCRIPTION
This pull request introduces the `StructuredError` type, which can be embedded into other structs to facilitate more robust and consistent error handling across the codebase.