### PR TITLE
use RawMessage in jsonResponseWrapper

### DIFF
--- a/payloads.go
+++ b/payloads.go
@@ -5,7 +5,7 @@ import (
 )
 
 type JSONResponseWrapper[T any] struct {
-	Raw     []byte
+	Raw     json.RawMessage
 	Decoded T
 }
 


### PR DESCRIPTION
When logging the wrapped response e.g. for debugging purposes using logrus, it will look like this:
```json
{
  "Raw": "eyJmaWVsZDEiOiAiZm9vIiwgImZpZWxkMiI6ICJiYXIifQ==",
  "Decoded": {
    "field1": "foo",
    "field2": "bar"
  }
}
```
Logrus uses `json.Marshal` to encode its fields, resulting in a Base64 encoded raw body.
Using `json.RawMessage` will fix this behavior by using the right encoding
