### PR TITLE
Add IsErrorWithStatusCode helper

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -12,6 +12,10 @@ func AsHTTPClientError(err error) (HTTPClientError, bool) {
 }
 
 func IsNotFound(err error) bool {
+	return IsErrorWithStatusCode(err, http.StatusNotFound)
+}
+
+func IsErrorWithStatusCode(err error, statusCode int) bool {
 	httpErr, ok := AsHTTPClientError(err)
-	return ok && httpErr.Code == http.StatusNotFound
+	return ok && httpErr.Code == statusCode
 }


### PR DESCRIPTION
The IsErrorWithStatusCode helper simplify checking for specific error codes, a very common use case.
We already had the IsNotFound helper and generalizes the same functionality for other status codes.